### PR TITLE
Add per-table structure/structure+data checklist for backups

### DIFF
--- a/app/Filament/Resources/DatabaseResource/Services/Backup/AbstractBackupRunner.php
+++ b/app/Filament/Resources/DatabaseResource/Services/Backup/AbstractBackupRunner.php
@@ -2,7 +2,13 @@
 
 namespace App\Filament\Resources\DatabaseResource\Services\Backup;
 
+use Filament\Forms\Components\Actions;
 use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification;
 
 abstract class AbstractBackupRunner
 {
@@ -15,6 +21,11 @@ abstract class AbstractBackupRunner
     }
 
     abstract public function run(): array;
+
+    /**
+     * List table names available on the target database using the given connection options.
+     */
+    abstract public static function listTables(array $options): array;
 
     public static function getLabel(): string
     {
@@ -32,4 +43,65 @@ abstract class AbstractBackupRunner
     }
 
     abstract public static function getFilamentBlockComponent(): Block;
+
+    /**
+     * Shared form schema letting the user, after connecting, checklist which
+     * tables to include in the backup and which of those should only have
+     * their structure (no data) backed up.
+     */
+    protected static function getTableSelectionSchema(): array
+    {
+        return [
+            Hidden::make('tables_options')
+                ->default([]),
+            Actions::make([
+                Actions\Action::make('loadTables')
+                    ->label('Muat Daftar Tabel')
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('gray')
+                    ->action(function (Get $get, Set $set) {
+                        $options = [
+                            'host' => $get('host'),
+                            'database' => $get('database'),
+                            'username' => $get('username'),
+                            'password' => $get('password'),
+                            'port' => $get('port'),
+                        ];
+
+                        $tables = static::listTables($options);
+
+                        $set('tables_options', $tables);
+
+                        if (empty($tables)) {
+                            Notification::make()
+                                ->title('Gagal memuat daftar tabel')
+                                ->body('Periksa kembali detail koneksi database.')
+                                ->danger()
+                                ->send();
+
+                            return;
+                        }
+
+                        Notification::make()
+                            ->title('Berhasil memuat '.count($tables).' tabel')
+                            ->success()
+                            ->send();
+                    }),
+            ]),
+            CheckboxList::make('tables')
+                ->label('Tabel yang di-backup')
+                ->helperText('Kosongkan untuk backup seluruh tabel (struktur + data).')
+                ->options(fn (Get $get) => $get('tables_options') ?? [])
+                ->columns(2)
+                ->bulkToggleable()
+                ->searchable(),
+            CheckboxList::make('structure_only_tables')
+                ->label('Backup Struktur Saja (tanpa data)')
+                ->helperText('Tabel yang dicentang di sini hanya akan di-backup strukturnya. Tabel lain yang dipilih di atas akan di-backup struktur + data.')
+                ->options(fn (Get $get) => $get('tables_options') ?? [])
+                ->columns(2)
+                ->bulkToggleable()
+                ->searchable(),
+        ];
+    }
 }

--- a/app/Filament/Resources/DatabaseResource/Services/Backup/Runner/MySQLBackupRunner.php
+++ b/app/Filament/Resources/DatabaseResource/Services/Backup/Runner/MySQLBackupRunner.php
@@ -30,27 +30,69 @@ class MySQLBackupRunner extends AbstractBackupRunner
         }
 
         // Generate the filename for the backup
-        $filename = $options['database'].'-backup-'.Carbon::now()->format('Y-m-d_H-i-s').'.gz';
+        $filename = $options['database'].'-backup-'.Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
 
         // Define the path to store the backup
         $path = storage_path().'/databases';
 
-        // Construct the command to perform the backup
-        $command = 'mariadb-dump --user='.$options['username'].
-            ' --password='.$options['password'].
-            ' --host='.$options['host'].
-            ' --skip-ssl'.
-            ' '.$options['database'].
-            '  | gzip > '.$path.'/'.$filename;
+        $sqlFile = $path.'/'.substr($filename, 0, -3);
 
-        // Execute the backup command
-        exec($command);
+        // Base command shared by all dumps
+        $baseCommand = 'mariadb-dump --user='.escapeshellarg($options['username']).
+            ' --password='.escapeshellarg($options['password']).
+            ' --host='.escapeshellarg($options['host']).
+            ' --skip-ssl';
+
+        $selectedTables = array_values(array_filter($options['tables'] ?? []));
+        $structureOnlyTables = array_values(array_intersect(
+            array_filter($options['structure_only_tables'] ?? []),
+            $selectedTables ?: array_filter($options['structure_only_tables'] ?? [])
+        ));
+
+        if (empty($selectedTables)) {
+            // No selection made: back up the whole database (structure + data)
+            exec($baseCommand.' '.escapeshellarg($options['database']).' > '.escapeshellarg($sqlFile));
+        } else {
+            $dataTables = array_diff($selectedTables, $structureOnlyTables);
+
+            if (! empty($structureOnlyTables)) {
+                $tables = implode(' ', array_map('escapeshellarg', $structureOnlyTables));
+                exec($baseCommand.' --no-data '.escapeshellarg($options['database']).' '.$tables.' > '.escapeshellarg($sqlFile));
+            }
+
+            if (! empty($dataTables)) {
+                $tables = implode(' ', array_map('escapeshellarg', $dataTables));
+                $redirect = file_exists($sqlFile) ? '>>' : '>';
+                exec($baseCommand.' '.escapeshellarg($options['database']).' '.$tables.' '.$redirect.' '.escapeshellarg($sqlFile));
+            }
+        }
+
+        // Compress the dump
+        exec('gzip -f '.escapeshellarg($sqlFile));
 
         // Return the path and filename of the backup
         return [
             'path' => $path,
             'filename' => $filename,
         ];
+    }
+
+    public static function listTables(array $options): array
+    {
+        try {
+            $pdo = new \PDO(
+                'mysql:host='.$options['host'].';port='.($options['port'] ?: 3306).';dbname='.$options['database'],
+                $options['username'],
+                $options['password'],
+                [\PDO::ATTR_TIMEOUT => 5]
+            );
+
+            $tables = $pdo->query('SHOW TABLES')->fetchAll(\PDO::FETCH_COLUMN);
+
+            return array_combine($tables, $tables);
+        } catch (\Throwable $e) {
+            return [];
+        }
     }
 
     public static function getFilamentBlockComponent(): Block
@@ -70,6 +112,7 @@ class MySQLBackupRunner extends AbstractBackupRunner
                     ->revealable(),
                 TextInput::make('port')
                     ->default('3306'),
+                ...static::getTableSelectionSchema(),
             ]);
     }
 }

--- a/app/Filament/Resources/DatabaseResource/Services/Backup/Runner/PostgreSQLBackupRunner.php
+++ b/app/Filament/Resources/DatabaseResource/Services/Backup/Runner/PostgreSQLBackupRunner.php
@@ -21,20 +21,44 @@ class PostgreSQLBackupRunner extends AbstractBackupRunner
             throw new \Exception('String options are not supported');
         }
 
-        $filename = $options['database'].'-backup-'.Carbon::now()->format('Y-m-d_H-i-s').'.gz';
+        $filename = $options['database'].'-backup-'.Carbon::now()->format('Y-m-d_H-i-s').'.sql.gz';
 
         $path = storage_path().'/databases';
 
+        $sqlFile = $path.'/'.substr($filename, 0, -3);
+
         putenv('PGPASSWORD='.$options['password']);
 
-        $command = 'PGPASSWORD='.$options['password'].
-            ' pg_dump --username='.$options['username'].
-            ' --port='.$options['port'].
-            ' --host='.$options['host'].
-            ' -d '.$options['database'].
-            '  | gzip > '.$path.'/'.$filename;
+        $baseCommand = 'pg_dump --username='.escapeshellarg($options['username']).
+            ' --port='.escapeshellarg($options['port']).
+            ' --host='.escapeshellarg($options['host']).
+            ' -d '.escapeshellarg($options['database']);
 
-        exec($command);
+        $selectedTables = array_values(array_filter($options['tables'] ?? []));
+        $structureOnlyTables = array_values(array_intersect(
+            array_filter($options['structure_only_tables'] ?? []),
+            $selectedTables ?: array_filter($options['structure_only_tables'] ?? [])
+        ));
+
+        if (empty($selectedTables)) {
+            // No selection made: back up the whole database (structure + data)
+            exec($baseCommand.' > '.escapeshellarg($sqlFile));
+        } else {
+            $dataTables = array_diff($selectedTables, $structureOnlyTables);
+
+            if (! empty($structureOnlyTables)) {
+                $tables = implode(' ', array_map(fn ($table) => '-t '.escapeshellarg($table), $structureOnlyTables));
+                exec($baseCommand.' --schema-only '.$tables.' > '.escapeshellarg($sqlFile));
+            }
+
+            if (! empty($dataTables)) {
+                $tables = implode(' ', array_map(fn ($table) => '-t '.escapeshellarg($table), $dataTables));
+                $redirect = file_exists($sqlFile) ? '>>' : '>';
+                exec($baseCommand.' '.$tables.' '.$redirect.' '.escapeshellarg($sqlFile));
+            }
+        }
+
+        exec('gzip -f '.escapeshellarg($sqlFile));
 
         putenv('PGPASSWORD=');
 
@@ -42,6 +66,25 @@ class PostgreSQLBackupRunner extends AbstractBackupRunner
             'path' => $path,
             'filename' => $filename,
         ];
+    }
+
+    public static function listTables(array $options): array
+    {
+        try {
+            $pdo = new \PDO(
+                'pgsql:host='.$options['host'].';port='.($options['port'] ?: 5432).';dbname='.$options['database'],
+                $options['username'],
+                $options['password'],
+                [\PDO::ATTR_TIMEOUT => 5]
+            );
+
+            $stmt = $pdo->query("SELECT tablename FROM pg_tables WHERE schemaname = 'public'");
+            $tables = $stmt->fetchAll(\PDO::FETCH_COLUMN);
+
+            return array_combine($tables, $tables);
+        } catch (\Throwable $e) {
+            return [];
+        }
     }
 
     public static function getFilamentBlockComponent(): Block
@@ -61,6 +104,7 @@ class PostgreSQLBackupRunner extends AbstractBackupRunner
                     ->revealable(),
                 TextInput::make('port')
                     ->default('5432'),
+                ...static::getTableSelectionSchema(),
             ]);
     }
 }


### PR DESCRIPTION
## Summary
- Setelah koneksi database diisi, tambahkan tombol "Muat Daftar Tabel" untuk mengambil daftar tabel dari database (MySQL & PostgreSQL).
- Tambahkan checklist "Tabel yang di-backup" untuk memilih tabel yang ingin di-backup (kosong = seluruh tabel, struktur + data, sesuai perilaku lama).
- Tambahkan checklist "Backup Struktur Saja" agar sebagian tabel yang dipilih bisa di-backup strukturnya saja tanpa data, sementara sisanya tetap struktur + data.
- `run()` pada `MySQLBackupRunner` dan `PostgreSQLBackupRunner` dipecah menjadi dua proses dump (structure-only vs structure+data) yang digabung menjadi satu file `.sql.gz`.

## Test plan
- [ ] `php -l` pada file yang diubah (sudah dijalankan, tidak ada syntax error)
- [ ] Uji manual di UI Filament: buat/edit database MySQL & PostgreSQL, klik "Muat Daftar Tabel", pilih beberapa tabel dan tandai sebagian sebagai struktur saja, jalankan backup, verifikasi isi file `.sql.gz` sesuai pilihan
- [ ] Uji default lama: tidak memilih tabel apapun tetap membackup seluruh database (struktur + data)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzPrTy386Fp5jqgnTW3uKY)_