### PR TITLE
Add configurable backup retention with automatic pruning

### DIFF
--- a/app/Console/Commands/PruneBackups.php
+++ b/app/Console/Commands/PruneBackups.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Database;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class PruneBackups extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:prune-backups';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete database backups that are older than their configured retention period';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        Database::query()
+            ->whereNotNull('retention_days')
+            ->get()
+            ->each(function (Database $database) {
+                $cutoff = Carbon::now()->subDays($database->retention_days);
+
+                $database->backup_histories()
+                    ->where('created_at', '<', $cutoff)
+                    ->get()
+                    ->each(function ($history) {
+                        try {
+                            @unlink($history->path.'/'.$history->filename);
+                        } finally {
+                            $history->delete();
+                        }
+                    });
+            });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,8 @@ class Kernel extends ConsoleKernel
         $schedule->command('db:backup "0 0 * * *"')->daily()->name('backup: daily');
         $schedule->command('db:backup "0 * * * *"')->hourly()->name('backup: hourly');
         $schedule->command('db:backup "* * * * *"')->everyMinute()->name('backup: every minute');
+
+        $schedule->command('db:prune-backups')->daily()->name('backup: prune expired');
     }
 
     /**

--- a/app/Filament/Resources/DatabaseResource.php
+++ b/app/Filament/Resources/DatabaseResource.php
@@ -34,6 +34,12 @@ class DatabaseResource extends Resource
                         '0 * * * *' => 'Every Hour',
                         '0 0 * * *' => 'Every 00:00',
                     ]),
+                TextInput::make('retention_days')
+                    ->label('Retensi Backup (hari)')
+                    ->helperText('Backup akan dihapus otomatis setelah sekian hari. Kosongkan untuk menyimpan backup selamanya.')
+                    ->numeric()
+                    ->minValue(1)
+                    ->nullable(),
                 Builder::make('data')
                     ->columnSpanFull()
                     ->blocks(
@@ -60,6 +66,10 @@ class DatabaseResource extends Resource
                 Tables\Columns\TextColumn::make('cron')
                     ->sortable()
                     ->searchable(),
+                Tables\Columns\TextColumn::make('retention_days')
+                    ->label('Retensi (hari)')
+                    ->placeholder('Selamanya')
+                    ->sortable(),
 
             ])
             ->actions([

--- a/app/Models/Database.php
+++ b/app/Models/Database.php
@@ -13,11 +13,13 @@ class Database extends Model
     protected $fillable = [
         'name',
         'cron',
+        'retention_days',
         'data',
     ];
 
     protected $casts = [
         'data' => 'array',
+        'retention_days' => 'integer',
     ];
 
     public function backup_histories(): HasMany

--- a/database/migrations/2026_08_12_000000_add_retention_days_to_databases_table.php
+++ b/database/migrations/2026_08_12_000000_add_retention_days_to_databases_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->unsignedInteger('retention_days')->nullable()->after('cron');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->dropColumn('retention_days');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Field baru "Retensi Backup (hari)" pada form database — kosongkan untuk menyimpan backup selamanya.
- Kolom retensi ditampilkan di tabel list database.
- Command baru `db:prune-backups` yang menghapus file backup beserta record history yang lebih tua dari `retention_days`, dijadwalkan berjalan harian.
- Migration untuk kolom `retention_days` pada tabel `databases`.

## Test plan
- [ ] `php -l` pada file yang diubah (sudah dijalankan, tidak ada syntax error)
- [ ] Jalankan migration dan pastikan kolom `retention_days` tersedia
- [ ] Set retensi pada sebuah database, jalankan `php artisan db:prune-backups`, verifikasi backup yang lebih tua dari retensi terhapus (file & record) sedangkan yang lebih baru tetap ada
- [ ] Pastikan database dengan retensi kosong tidak pernah di-prune

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzPrTy386Fp5jqgnTW3uKY)_